### PR TITLE
Fixing onNeighborUpdate

### DIFF
--- a/src/main/java/fi/dy/masa/minihud/util/DebugInfoUtils.java
+++ b/src/main/java/fi/dy/masa/minihud/util/DebugInfoUtils.java
@@ -140,7 +140,7 @@ public class DebugInfoUtils
         if (neighborUpdateEnabled && world.isClient == false)
         {
             MinecraftClient.getInstance().execute(() -> {
-                ((NeighborUpdateDebugRenderer) MinecraftClient.getInstance().debugRenderer.neighborUpdateDebugRenderer).addNeighborUpdate(world.getTime(), pos);
+                ((NeighborUpdateDebugRenderer) MinecraftClient.getInstance().debugRenderer.neighborUpdateDebugRenderer).addNeighborUpdate(world.getTime(), pos.mutableCopy());
             });
         }
     }


### PR DESCRIPTION
Fixing onNeighborUpdate not displaying tree block updates correctly due to mutable being passed in